### PR TITLE
Fix for windows assets path

### DIFF
--- a/src/Routing/StaticAssets/AssetManager.ts
+++ b/src/Routing/StaticAssets/AssetManager.ts
@@ -65,7 +65,7 @@ export class AssetManager {
 				.replace(/^\//, '');
 
 			AssetManager.assetPaths.push(
-				encodeURI(path.join(this.assetDir, file)).replace(/\/\//g, '/')
+				encodeURI(path.join(this.assetDir, file).replace(/\\/g, '/')).replace(/\/\//g, '/')
 			);
 		}
 


### PR DESCRIPTION
find-my-way does not allow any file pathing unless they start with '/' or '*' so windows breaks.